### PR TITLE
Drug evaluators for toxicity added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - docker build -f .travis/Dockerfile -t generator .
 script:
   - docker run -it generator python3 -c "import paccmann_generator"
+  - docker run -it generator python3 -m unittest discover -t . -p "test_*py" paccmann_generator
   - docker run -it generator python3 examples/train_paccmann_rl.py -h
 notifications:
   slack:

--- a/conda.yml
+++ b/conda.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.6,<3.8
   - pip>=19.1
   - pip:
-    - pytoda @ git+https://git@github.com/PaccMann/paccmann_datasets@0.0.1
+    - pytoda @ git+https://git@github.com/PaccMann/paccmann_datasets@latest
     - numpy>=1.14.3
     - pandas>=0.24.1
     - torch>=1.0.1

--- a/paccmann_generator/drug_evaluators/__init__.py
+++ b/paccmann_generator/drug_evaluators/__init__.py
@@ -5,3 +5,7 @@ from .sas import SAS  # noqa
 from .molecular_weight import MolecularWeight  # noqa
 from .scsore import SCScore  # noqa
 from .lipinski import Lipinski  # noqa
+from .tox21 import Tox21  # noqa
+from .organdb import OrganDB  # noqa
+from .sider import SIDER  # noqa
+from .clintox import ClinTox  # noqa

--- a/paccmann_generator/drug_evaluators/clintox.py
+++ b/paccmann_generator/drug_evaluators/clintox.py
@@ -1,0 +1,79 @@
+#%%
+"""ClinTox evaluator."""
+from .drug_evaluator import DrugEvaluator
+
+
+class ClinTox(DrugEvaluator):
+    """
+    ClinTox evaluation class.
+    Inherits from DrugEvaluator and evaluates the clinically observed toxicity.
+    2 Classes:
+        First one is probability to receive FDA approval.
+        Second is probability of failure in clinical stage.
+    """
+
+    def __init__(self, model_path, reward_type='thresholded'):
+        """
+
+        Arguments:
+            model_path {string} -- Path to the pretrained model
+        
+        Keyword Arguments:
+            reward_type {string} -- From {'thresholded', 'raw'}. If 'raw' the
+                average of the raw predictions is used as reward.
+                If `thresholded`, reward is 1 iff probability to get approval
+                is > 0.5 and probability of clinical failure is < 0.5.
+        """
+
+        super(ClinTox, self).__init__()
+        self.load_mca(model_path)
+
+        self.set_reward_fn(reward_type)
+
+    def set_reward_fn(self, reward_type):
+        self.reward_type = reward_type
+        if reward_type == 'thresholded':
+            self.reward_fn = lambda x: (
+                1. if x[:, 0] > .5 and x[:, 1] < .5 else 0.
+            )
+        elif reward_type == 'raw':
+            # Average probabilities
+            self.reward_fn = lambda x: float((x[0] + 1 - x[1]) / 2)
+        else:
+            raise ValueError(f'Unknown reward_type given: {reward_type}')
+
+    def __call__(self, smiles):
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles {str} -- SMILES of molecule
+        Returns:
+            float -- Averaged  predictions from the model
+
+        TODO: Should be able to understand iterables
+        """
+        # Error handling.
+        if not type(smiles) == str:
+            raise TypeError(f'Input must be String, not :{type(smiles)}')
+
+        smiles_tensor = self.preprocess_smiles(smiles)
+        return self.clintox_score(smiles_tensor)
+
+    def clintox_score(self, smiles_tensor):
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles_tensor {str} -- SMILES
+
+        Returns:
+            float -- Averaged  predictions from the model
+        """
+
+        # Test the compound
+        predictions, _ = self.model(smiles_tensor)
+        # To allow accessing the raw predictions from outside
+        self.predictions = predictions[0, :]
+
+        return self.reward_fn(self.predictions)

--- a/paccmann_generator/drug_evaluators/clintox.py
+++ b/paccmann_generator/drug_evaluators/clintox.py
@@ -1,6 +1,7 @@
 #%%
 """ClinTox evaluator."""
 from .drug_evaluator import DrugEvaluator
+import torch
 
 
 class ClinTox(DrugEvaluator):
@@ -12,7 +13,7 @@ class ClinTox(DrugEvaluator):
         Second is probability of failure in clinical stage.
     """
 
-    def __init__(self, model_path, reward_type='thresholded'):
+    def __init__(self, model_path: str, reward_type: str = 'thresholded'):
         """
 
         Arguments:
@@ -30,7 +31,7 @@ class ClinTox(DrugEvaluator):
 
         self.set_reward_fn(reward_type)
 
-    def set_reward_fn(self, reward_type):
+    def set_reward_fn(self, reward_type: str):
         self.reward_type = reward_type
         if reward_type == 'thresholded':
             self.reward_fn = lambda x: (
@@ -42,7 +43,7 @@ class ClinTox(DrugEvaluator):
         else:
             raise ValueError(f'Unknown reward_type given: {reward_type}')
 
-    def __call__(self, smiles):
+    def __call__(self, smiles: str) -> float:
         """
         Forward pass through the model.
 
@@ -60,12 +61,12 @@ class ClinTox(DrugEvaluator):
         smiles_tensor = self.preprocess_smiles(smiles)
         return self.clintox_score(smiles_tensor)
 
-    def clintox_score(self, smiles_tensor):
+    def clintox_score(self, smiles_tensor: torch.Tensor) -> float:
         """
         Forward pass through the model.
 
         Arguments:
-            smiles_tensor {str} -- SMILES
+            smiles_tensor {torch.Tensor} -- Tensor of shape 2 x SMILES_tokens
 
         Returns:
             float -- Averaged  predictions from the model

--- a/paccmann_generator/drug_evaluators/drug_evaluator.py
+++ b/paccmann_generator/drug_evaluators/drug_evaluator.py
@@ -1,4 +1,16 @@
 """Drug evaluator."""
+import json
+import os
+from cytotox.models import MODEL_FACTORY
+
+from paccmann_predictor.utils.utils import get_device
+from pytoda.smiles.smiles_language import SMILESLanguage
+from pytoda.smiles.transforms import (
+    Canonicalization, Kekulize, NotKekulize, RemoveIsomery, Selfies,
+    SMILESToTokenIndexes, ToTensor
+)
+from pytoda.transforms import Compose
+import torch
 
 
 class DrugEvaluator:
@@ -8,6 +20,102 @@ class DrugEvaluator:
     drug evaluation metrics.
     """
 
+    def __init__(self):
+        self.device = get_device()
+
     def __call__(self, smiles):
 
         raise NotImplementedError
+
+    def load_mca(self, model_path):
+        """
+        Restores pretrained MCA
+
+        Arguments:
+            model_path {String} -- Path to the model
+        """
+
+        # Restore Tox21 model
+        self.model_path = model_path
+        with open(os.path.join(model_path, 'model_params.json')) as f:
+            params = json.load(f)
+
+        # Set up language and transforms
+        self.smiles_language = SMILESLanguage.load(
+            os.path.join(model_path, 'smiles_language.pkl')
+        )
+        self.transforms = self.compose_smiles_transforms(params)
+
+        # Initialize and restore model weights
+        self.model = MODEL_FACTORY['mca'](params)
+        self.model.load(
+            os.path.join(model_path, 'weights', 'best_ROC-AUC_mca.pt'),
+            map_location=get_device()
+        )
+        self.model.eval()
+
+    def compose_smiles_transforms(self, params):
+        """
+        Apply transforms that were applied during model training
+
+        Arguments:
+            smiles {str} -- [description]
+        Returns:
+            smiles (torch.Tensor)
+        """
+
+        self.canonical = params.get('canonical', False)
+        self.kekulize = params.get('kekulize', False)
+        self.canonical = params.get('canonical', False)
+        self.all_bonds_explicit = params.get('all_bonds_explicit', False)
+        self.all_hs_explicit = params.get('all_hs_explicit', False)
+        self.remove_bonddir = params.get('remove_bonddir', False)
+        self.remove_chirality = params.get('remove_chirality', False)
+        self.selfies = params.get('selfies', False)
+
+        transforms = []
+        if self.canonical:
+            transforms += [Canonicalization()]
+        else:
+            if self.remove_bonddir or self.remove_chirality:
+                transforms += [
+                    RemoveIsomery(
+                        bonddir=self.remove_bonddir,
+                        chirality=self.remove_chirality
+                    )
+                ]
+            if self.kekulize:
+                transforms += [
+                    Kekulize(
+                        all_bonds_explicit=self.all_bonds_explicit,
+                        all_hs_explicit=self.all_hs_explicit
+                    )
+                ]
+            elif self.all_bonds_explicit or self.all_hs_explicit:
+                transforms += [
+                    NotKekulize(
+                        all_bonds_explicit=self.all_bonds_explicit,
+                        all_hs_explicit=self.all_hs_explicit
+                    )
+                ]
+            if self.selfies:
+                transforms += [Selfies()]
+
+        transforms += [
+            SMILESToTokenIndexes(smiles_language=self.smiles_language)
+        ]
+        transforms += [ToTensor(device=self.device)]
+
+        return Compose(transforms)
+
+    def preprocess_smiles(self, smiles):
+        """
+        Apply transforms that were applied during model training.
+
+        Arguments:
+            smiles {str} -- SMILES of molecules
+        Returns:
+            smiles (torch.Tensor) -- Tensor of shape 2 x T (unpadded but
+                repeated twice to circumvent possible batch norm difficulties).
+        """
+        return torch.unsqueeze(self.transforms(smiles), 0).repeat(2, 1)

--- a/paccmann_generator/drug_evaluators/drug_evaluator.py
+++ b/paccmann_generator/drug_evaluators/drug_evaluator.py
@@ -23,11 +23,11 @@ class DrugEvaluator:
     def __init__(self):
         self.device = get_device()
 
-    def __call__(self, smiles):
+    def __call__(self, smiles: str):
 
         raise NotImplementedError
 
-    def load_mca(self, model_path):
+    def load_mca(self, model_path: str):
         """
         Restores pretrained MCA
 
@@ -54,14 +54,14 @@ class DrugEvaluator:
         )
         self.model.eval()
 
-    def compose_smiles_transforms(self, params):
+    def compose_smiles_transforms(self, params: dict) -> Compose:
         """
-        Apply transforms that were applied during model training
+        Create transforms that were applied during model training
 
         Arguments:
-            smiles {str} -- [description]
+            params {dict} -- Model parameter to retrieve transforms
         Returns:
-            smiles (torch.Tensor)
+            Compose -- Object to perform transforms
         """
 
         self.canonical = params.get('canonical', False)
@@ -108,7 +108,7 @@ class DrugEvaluator:
 
         return Compose(transforms)
 
-    def preprocess_smiles(self, smiles):
+    def preprocess_smiles(self, smiles: str) -> torch.Tensor:
         """
         Apply transforms that were applied during model training.
 

--- a/paccmann_generator/drug_evaluators/organdb.py
+++ b/paccmann_generator/drug_evaluators/organdb.py
@@ -1,0 +1,89 @@
+"""OrganDB evaluator."""
+import rdkit
+from rdkit import Chem
+import argparse
+import json
+import logging
+import os
+import torch
+import pickle
+import sys
+import seaborn as sns
+import matplotlib.pyplot as plt
+from torch import nn
+import numpy as np
+from collections import OrderedDict
+from paccmann_predictor.utils.utils import get_device
+import pandas as pd
+from cytotox.models import MODEL_FACTORY
+from pytoda.smiles.smiles_language import SMILESLanguage
+from pytoda.smiles.transforms import SMILESToTokenIndexes
+from cytotox.utils.utils import disable_rdkit_logging
+from .drug_evaluator import DrugEvaluator
+from pytoda.transforms import Transform
+from pytoda.smiles.transforms import LeftPadding
+
+
+class OrganDB(DrugEvaluator):
+    """
+    OrganDB evaluation class.
+    Inherits from DrugEvaluator and evaluates the OrganDB score of a SMILES.
+    Organs can be:
+        'Adrenal Gland', 'Bone Marrow', 'Brain', 'Eye',
+        'Heart', 'Kidney', 'Liver', 'Lung', 'Lymph Node',
+        'Mammary Gland', 'Pancreas', 'Pituitary Gland',
+        'Spleen', 'Stomach', 'Testes', 'Thymus',
+        'Thyroid Gland', 'Urinary Bladder', 'Uterus', 'Ovary'
+    """
+
+    def __init__(self):
+
+        super(OrganDB, self).__init__()
+
+    def __call__(self, mol, *organ):
+        """
+        Returns the OrganDB of a SMILES string or a RdKit molecule.
+        """
+        # Check if molecule is valid
+        # Error handling.
+        if type(mol) == rdkit.Chem.rdchem.Mol:
+            pass
+        elif type(mol) == str:
+            mol = Chem.MolFromSmiles(mol, sanitize=False)
+            if mol is None:
+                raise ValueError("Invalid SMILES string.")
+        else:
+            raise TypeError("Input must be from {str, rdkit.Chem.rdchem.Mol}")
+        
+        return self.organdb_score(mol, *organ)
+
+        
+    def task_specificity(self, pred_organdb_per_task, organ):
+        task_names = [
+            'CHR:Adrenal Gland', 'CHR:Bone Marrow', 'CHR:Brain', 'CHR:Eye',
+            'CHR:Heart', 'CHR:Kidney', 'CHR:Liver', 'CHR:Lung', 'CHR:Lymph Node',
+            'CHR:Mammary Gland', 'CHR:Pancreas', 'CHR:Pituitary Gland',
+            'CHR:Spleen', 'CHR:Stomach', 'CHR:Testes', 'CHR:Thymus',
+            'CHR:Thyroid Gland', 'CHR:Urinary Bladder', 'CHR:Uterus', 'MGR:Brain',
+            'MGR:Kidney', 'MGR:Ovary', 'MGR:Testes', 'SUB:Adrenal Gland',
+            'SUB:Bone Marrow', 'SUB:Brain', 'SUB:Heart', 'SUB:Kidney', 'SUB:Liver',
+            'SUB:Lung', 'SUB:Spleen', 'SUB:Stomach', 'SUB:Testes', 'SUB:Thymus',
+            'SUB:Thyroid Gland'
+        ]
+        chronics = []
+        for ind,i in enumerate(task_names):
+            if organ in i:
+                chronics.append(pred_organdb_per_task[ind])
+        average_over_chronics = sum(chronics)/len(chronics)
+        
+        return average_over_chronics
+    
+    def organdb_score(self, mol, *organ):
+        # model.load()
+        # Test the compound
+        smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)
+        pred_organdb_per_task, pred_dict = organdb_predictor(smiles_t)
+        #pred_organdb_average = sum(pred_tox21_per_task)/35
+        average_over_chronics = task_specificity(pred_organdb_per_task,organ)
+        
+        return average_over_chronics

--- a/paccmann_generator/drug_evaluators/organdb.py
+++ b/paccmann_generator/drug_evaluators/organdb.py
@@ -1,27 +1,31 @@
 """OrganDB evaluator."""
-import rdkit
-from rdkit import Chem
-import argparse
-import json
-import logging
-import os
 import torch
-import pickle
-import sys
-import seaborn as sns
-import matplotlib.pyplot as plt
-from torch import nn
-import numpy as np
-from collections import OrderedDict
-from paccmann_predictor.utils.utils import get_device
-import pandas as pd
-from cytotox.models import MODEL_FACTORY
-from pytoda.smiles.smiles_language import SMILESLanguage
-from pytoda.smiles.transforms import SMILESToTokenIndexes
-from cytotox.utils.utils import disable_rdkit_logging
 from .drug_evaluator import DrugEvaluator
-from pytoda.transforms import Transform
-from pytoda.smiles.transforms import LeftPadding
+
+TASK_NAMES = [
+    'CHR:Adrenal Gland', 'CHR:Bone Marrow', 'CHR:Brain', 'CHR:Eye',
+    'CHR:Heart', 'CHR:Kidney', 'CHR:Liver', 'CHR:Lung', 'CHR:Lymph Node',
+    'CHR:Mammary Gland', 'CHR:Pancreas', 'CHR:Pituitary Gland', 'CHR:Spleen',
+    'CHR:Stomach', 'CHR:Testes', 'CHR:Thymus', 'CHR:Thyroid Gland',
+    'CHR:Urinary Bladder', 'CHR:Uterus', 'MGR:Brain', 'MGR:Kidney',
+    'MGR:Ovary', 'MGR:Testes', 'SUB:Adrenal Gland', 'SUB:Bone Marrow',
+    'SUB:Brain', 'SUB:Heart', 'SUB:Kidney', 'SUB:Liver', 'SUB:Lung',
+    'SUB:Spleen', 'SUB:Stomach', 'SUB:Testes', 'SUB:Thymus',
+    'SUB:Thyroid Gland'
+]
+
+SITES = [
+    'Adrenal Gland', 'Bone Marrow', 'Brain', 'Eye', 'Heart', 'Kidney', 'Liver',
+    'Lung', 'Lymph Node', 'Mammary Gland', 'Pancreas', 'Pituitary Gland',
+    'Spleen', 'Stomach', 'Testes', 'Thymus', 'Thyroid Gland',
+    'Urinary Bladder', 'Uterus', 'Ovary'
+]
+TOXICITIES = {
+    'chronic': ['CHR'],
+    'subchronic': ['SUB'],
+    'multigenerational': ['MGR'],
+    'all': ['CHR', 'SUB', 'MGR']
+}
 
 
 class OrganDB(DrugEvaluator):
@@ -34,63 +38,133 @@ class OrganDB(DrugEvaluator):
         'Mammary Gland', 'Pancreas', 'Pituitary Gland',
         'Spleen', 'Stomach', 'Testes', 'Thymus',
         'Thyroid Gland', 'Urinary Bladder', 'Uterus', 'Ovary'
+
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        model_path: str,
+        site: str,
+        toxicity_type: str = 'all',
+        reward_type: str = 'thresholded'
+    ):
+        """
+        Arguments:
+            model_path (string): Path to the pretrained model
+            site (string):  Name of organ of interest
+
+        Keyword Arguments:
+            toxicity_type (string): Type of toxicity from
+                {'all', 'chronic', 'subcronic', 'multigenerational'}. Defaults
+                to 'all'.
+            reward_type {string} -- From {'thresholded', 'raw'}. If 'raw' the
+                (inverted) average of the raw predictions is used as reward.
+                If `thresholded`, reward is 1 iff all predictions are < 0.5.
+        """
 
         super(OrganDB, self).__init__()
+        self.load_mca(model_path)
+        self.set_reward_fn(site, toxicity_type, reward_type)
 
-    def __call__(self, mol, organ):
+    def set_reward_fn(self, site: str, toxicity_type: str, reward_type: str):
         """
-        Returns the OrganDB of a SMILES string or a RdKit molecule.
+        Updates the reward function.
+        Arguments:
+            toxicity_type (string): Type of toxicity from
+                {'all', 'chronic', 'subcronic', 'multigenerational'}. Defaults
+                to 'all'.
+            reward_type (string): From {'thresholded', 'raw'}. If 'raw' the
+                (inverted) average of the raw predictions is used as reward.
+                If `thresholded`, reward is 1 iff all predictions are < 0.5.
         """
-        # Check if molecule is valid
-        # Error handling.
-        if type(mol) == rdkit.Chem.rdchem.Mol:
-            pass
-        elif type(mol) == str:
-            mol = Chem.MolFromSmiles(mol, sanitize=False)
-            if mol is None:
-                raise ValueError("Invalid SMILES string.")
-        else:
-            raise TypeError("Input must be from {str, rdkit.Chem.rdchem.Mol}")
-        
-        return self.organdb_score(mol, *organ)
 
-        
-    def task_specificity(self, pred_organdb_per_task, organ):
-        task_names = [
-            'CHR:Adrenal Gland', 'CHR:Bone Marrow', 'CHR:Brain', 'CHR:Eye',
-            'CHR:Heart', 'CHR:Kidney', 'CHR:Liver', 'CHR:Lung', 'CHR:Lymph Node',
-            'CHR:Mammary Gland', 'CHR:Pancreas', 'CHR:Pituitary Gland',
-            'CHR:Spleen', 'CHR:Stomach', 'CHR:Testes', 'CHR:Thymus',
-            'CHR:Thyroid Gland', 'CHR:Urinary Bladder', 'CHR:Uterus', 'MGR:Brain',
-            'MGR:Kidney', 'MGR:Ovary', 'MGR:Testes', 'SUB:Adrenal Gland',
-            'SUB:Bone Marrow', 'SUB:Brain', 'SUB:Heart', 'SUB:Kidney', 'SUB:Liver',
-            'SUB:Lung', 'SUB:Spleen', 'SUB:Stomach', 'SUB:Testes', 'SUB:Thymus',
-            'SUB:Thyroid Gland'
+        # Error handling
+        site = site.strip().lower()
+        if not any(list(map(lambda s: site in s.strip().lower(), SITES))):
+            raise ValueError(f'Unknown site: ({site}). Chose from: {SITES}')
+
+        toxicity_type = toxicity_type.strip().lower()
+        if toxicity_type not in TOXICITIES.keys():
+            raise ValueError(
+                f'Unknown toxicity type: {toxicity_type}. '
+                f'Chose from: {TOXICITIES.keys()}'
+            )
+
+        # Select right classes
+        class_indices = [
+            i for i, x in enumerate(
+                list(
+                    map(
+                        lambda task: site.lower() in task.lower() and any(
+                            list(
+                                map(
+                                    lambda t: t.lower() in task.lower(),
+                                    TOXICITIES[toxicity_type]
+                                )
+                            )
+                        ), TASK_NAMES
+                    )
+                )
+            ) if x
         ]
-        chronics = []
-        for ind,i in enumerate(task_names):
-            if organ in i:
-                chronics.append(pred_organdb_per_task[ind])
-        average_over_chronics = sum(chronics)/len(chronics)
-        
-        return average_over_chronics
-    
-    def organdb_score(self, mol, organ):
-        # TODO: load model
-        
+        if len(class_indices) == 0:
+            raise ValueError(
+                f'Model cannot perform predictions for organ: {site} and '
+                f'toxicity type: {toxicity_type}.'
+            )
+        self.toxicity_type = toxicity_type
+        self.site = site
+        self.class_indices = class_indices
+
+        # Class names
+        self.classes = [TASK_NAMES[c] for c in class_indices]
+
+        if reward_type == 'thresholded':
+            # If any assay was positive, no reward is given
+            self.reward_fn = lambda yhat, classes: 0. if any(
+                yhat[classes] > 0.5
+            ) else 1.
+        elif reward_type == 'raw':
+            # Average probabilities and invert to get reward
+            self.reward_fn = lambda yhat, classes: 1. - float(
+                yhat[classes].mean()
+            )
+        else:
+            raise ValueError(f'Unknown reward_type given: {reward_type}')
+
+        self.reward_type = reward_type
+
+    def __call__(self, smiles: str) -> float:
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles {str} -- SMILES of molecule
+        Returns:
+            float -- Reward used for the generator (high reward = low toxicity)
+
+        TODO: Should be able to understand iterables
+        """
+        # Error handling.
+        if not type(smiles) == str:
+            raise TypeError(f'Input must be String, not :{type(smiles)}')
+
+        smiles_tensor = self.preprocess_smiles(smiles)
+        return self.organdb_score(smiles_tensor)
+
+    def organdb_score(self, smiles_tensor: torch.Tensor) -> float:
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles_tensor {torch.Tensor} -- Tensor of shape 2 x SMILES_tokens
+
+        Returns:
+            float -- Reward
+        """
         # Test the compound
-        with open(os.path.join(organdb_model_path, 'model_params.json')) as f:
-            organdb_params = json.load(f)
-        mol = MODEL_FACTORY['mca'](organdb_params)
-        # TODO: Compose(transforms)
-        
-        smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)
-        pred_organdb_per_task, pred_dict = organdb_predictor(smiles_t)
-        #pred_organdb_average = sum(pred_tox21_per_task)/35
-        average_over_chronics = task_specificity(pred_organdb_per_task,organ)
-        organdb_score = average_over_chronics
-        
-        return organdb_score
+        predictions, _ = self.model(smiles_tensor)
+        # To allow accessing the raw predictions from outside
+        self.predictions = predictions[0, :]
+
+        return self.reward_fn(self.predictions, self.class_indices)

--- a/paccmann_generator/drug_evaluators/organdb.py
+++ b/paccmann_generator/drug_evaluators/organdb.py
@@ -79,11 +79,18 @@ class OrganDB(DrugEvaluator):
         return average_over_chronics
     
     def organdb_score(self, mol, organ):
-        # model.load()
+        # TODO: load model
+        
         # Test the compound
+        with open(os.path.join(organdb_model_path, 'model_params.json')) as f:
+            organdb_params = json.load(f)
+        mol = MODEL_FACTORY['mca'](organdb_params)
+        # TODO: Compose(transforms)
+        
         smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)
         pred_organdb_per_task, pred_dict = organdb_predictor(smiles_t)
         #pred_organdb_average = sum(pred_tox21_per_task)/35
         average_over_chronics = task_specificity(pred_organdb_per_task,organ)
+        organdb_score = average_over_chronics
         
-        return average_over_chronics
+        return organdb_score

--- a/paccmann_generator/drug_evaluators/organdb.py
+++ b/paccmann_generator/drug_evaluators/organdb.py
@@ -40,7 +40,7 @@ class OrganDB(DrugEvaluator):
 
         super(OrganDB, self).__init__()
 
-    def __call__(self, mol, *organ):
+    def __call__(self, mol, organ):
         """
         Returns the OrganDB of a SMILES string or a RdKit molecule.
         """
@@ -78,7 +78,7 @@ class OrganDB(DrugEvaluator):
         
         return average_over_chronics
     
-    def organdb_score(self, mol, *organ):
+    def organdb_score(self, mol, organ):
         # model.load()
         # Test the compound
         smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)

--- a/paccmann_generator/drug_evaluators/sider.py
+++ b/paccmann_generator/drug_evaluators/sider.py
@@ -1,0 +1,56 @@
+#%%
+"""SIDER evaluator."""
+from .drug_evaluator import DrugEvaluator
+
+
+class SIDER(DrugEvaluator):
+    """
+    SIDER evaluation class.
+    Inherits from DrugEvaluator and evaluates the side effects of a SMILES.
+    """
+
+    def __init__(self, model_path):
+        """
+
+        Arguments:
+            model_path {string} -- Path to the pretrained model
+        """
+
+        super(SIDER, self).__init__()
+        self.load_mca(model_path)
+
+    def __call__(self, smiles):
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles {str} -- SMILES of molecule
+        Returns:
+            float -- Averaged  predictions from the model
+
+        TODO: Should be able to understand iterables
+        """
+        # Error handling.
+        if not type(smiles) == str:
+            raise TypeError(f'Input must be String, not :{type(smiles)}')
+
+        smiles_tensor = self.preprocess_smiles(smiles)
+        return self.sider_score(smiles_tensor)
+
+    def sider_score(self, smiles_tensor):
+        """
+        Forward pass through the model.
+
+        Arguments:
+            smiles_tensor {str} -- SMILES
+
+        Returns:
+            float -- Averaged  predictions from the model
+        """
+
+        # Test the compound
+        predictions, _ = self.model(smiles_tensor)
+        # To allow accessing the raw predictions from outside
+        self.predictions = predictions[0, :]
+
+        return 1. - float(self.predictions.mean())

--- a/paccmann_generator/drug_evaluators/sider.py
+++ b/paccmann_generator/drug_evaluators/sider.py
@@ -1,6 +1,7 @@
 #%%
 """SIDER evaluator."""
 from .drug_evaluator import DrugEvaluator
+import torch
 
 
 class SIDER(DrugEvaluator):
@@ -9,7 +10,7 @@ class SIDER(DrugEvaluator):
     Inherits from DrugEvaluator and evaluates the side effects of a SMILES.
     """
 
-    def __init__(self, model_path):
+    def __init__(self, model_path: str):
         """
 
         Arguments:
@@ -19,7 +20,7 @@ class SIDER(DrugEvaluator):
         super(SIDER, self).__init__()
         self.load_mca(model_path)
 
-    def __call__(self, smiles):
+    def __call__(self, smiles: str) -> float:
         """
         Forward pass through the model.
 
@@ -37,13 +38,13 @@ class SIDER(DrugEvaluator):
         smiles_tensor = self.preprocess_smiles(smiles)
         return self.sider_score(smiles_tensor)
 
-    def sider_score(self, smiles_tensor):
+    def sider_score(self, smiles_tensor: torch.Tensor) -> float:
         """
         Forward pass through the model.
 
         Arguments:
-            smiles_tensor {str} -- SMILES
-
+            smiles_tensor {torch.Tensor} -- Tensor of shape 2 x SMILES_tokens
+            
         Returns:
             float -- Averaged  predictions from the model
         """

--- a/paccmann_generator/drug_evaluators/tests/test_organdb.py
+++ b/paccmann_generator/drug_evaluators/tests/test_organdb.py
@@ -1,0 +1,54 @@
+"""Testing OrganDB model."""
+import unittest
+import torch
+import numpy as np
+from paccmann_generator.drug_evaluators import OrganDB
+
+
+# To bypass constructor (model loading)
+class FakeOrganDB(OrganDB):
+
+    def __init__(self):
+        pass
+
+
+class TestOrganDB(unittest.TestCase):
+    """Testing OrganDB model """
+
+    def test_set_reward_fn(self) -> None:
+        """Test set_reward_fn."""
+
+        sites = ['lUnG  ', 'Brain']
+        toxicity_types = [' ChroniC ', 'ALL']
+        reward_types = ['thresholded', 'raw']
+        gt_classes = [
+            ['CHR:Lung'], ['CHR:Lung'], ['CHR:Lung', 'SUB:Lung'],
+            ['CHR:Lung', 'SUB:Lung'], ['CHR:Brain'], ['CHR:Brain'],
+            ['CHR:Brain', 'MGR:Brain', 'SUB:Brain'],
+            ['CHR:Brain', 'MGR:Brain', 'SUB:Brain']
+        ]
+        dummy_predictions = torch.arange(35) / 35.
+        gt_rewards = [
+            1., 1 - (7 / 35), 0., 1 - (((7 / 35) + (29 / 35)) / 2), 1.,
+            1 - (2 / 35), 0., 1 - (((2 / 35) + (19 / 35) + (25 / 35)) / 3)
+        ]
+
+        ind = -1
+        for site in sites:
+            for toxicity_type in toxicity_types:
+                for reward_type in reward_types:
+                    ind += 1
+                    o = FakeOrganDB()
+                    o.set_reward_fn(
+                        site=site,
+                        toxicity_type=toxicity_type,
+                        reward_type=reward_type
+                    )
+                    self.assertEqual(o.classes, gt_classes[ind])
+                    self.assertEqual(o.site, site.lower().strip())
+                    reward = o.reward_fn(dummy_predictions, o.class_indices)
+                    self.assertTrue(np.allclose(reward, gt_rewards[ind]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paccmann_generator/drug_evaluators/tox21.py
+++ b/paccmann_generator/drug_evaluators/tox21.py
@@ -23,7 +23,7 @@ from .drug_evaluator import DrugEvaluator
 from pytoda.transforms import Transform
 from pytoda.smiles.transforms import LeftPadding
 
-# toxic_model_path = os.path.join(
+# tox21_model_path = os.path.join(
 #     os.path.expanduser('~'),
 #     'Box/Molecular_SysBio/data/cytotoxicity/models/Tox21/raw_aug_MCA_5'
 # )
@@ -64,13 +64,20 @@ class Tox21(DrugEvaluator):
     
 
     def tox21_score(self, mol)
-        # model.load(path)
+        # TODO: load model
+        
+        
         with open(os.path.join(tox21_model_path, 'model_params.json')) as f:
             tox21_params = json.load(f)
         mol = MODEL_FACTORY['mca'](tox21_params)
+        
+        #TODO: Compose(transforms)
+        
+        
         # Test the compound
         smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)
         pred_tox21_per_task, pred_dict = tox21_predictor(smiles_t)
         pred_tox21_average = sum(pred_tox21_per_task)/12
+        tox21_score = pred_tox21_average
 
-        return pred_tox21_average
+        return tox21_score

--- a/paccmann_generator/drug_evaluators/tox21.py
+++ b/paccmann_generator/drug_evaluators/tox21.py
@@ -1,6 +1,7 @@
 #%%
 """Tox21 evaluator."""
 from .drug_evaluator import DrugEvaluator
+import torch
 
 
 class Tox21(DrugEvaluator):
@@ -9,7 +10,7 @@ class Tox21(DrugEvaluator):
     Inherits from DrugEvaluator and evaluates the Tox21 score of a SMILES.
     """
 
-    def __init__(self, model_path, reward_type='thresholded'):
+    def __init__(self, model_path: str, reward_type: str = 'thresholded'):
         """
 
         Arguments:
@@ -26,7 +27,7 @@ class Tox21(DrugEvaluator):
 
         self.set_reward_fn(reward_type)
 
-    def set_reward_fn(self, reward_type):
+    def set_reward_fn(self, reward_type: str):
         self.reward_type = reward_type
         if reward_type == 'thresholded':
             # If any assay was positive, no reward is given
@@ -37,7 +38,7 @@ class Tox21(DrugEvaluator):
         else:
             raise ValueError(f'Unknown reward_type given: {reward_type}')
 
-    def __call__(self, smiles):
+    def __call__(self, smiles: str) -> float:
         """
         Forward pass through the model.
 
@@ -55,15 +56,15 @@ class Tox21(DrugEvaluator):
         smiles_tensor = self.preprocess_smiles(smiles)
         return self.tox21_score(smiles_tensor)
 
-    def tox21_score(self, smiles_tensor):
+    def tox21_score(self, smiles_tensor: torch.Tensor) -> float:
         """
         Forward pass through the model.
 
         Arguments:
-            smiles_tensor {str} -- SMILES
+            smiles_tensor {torch.Tensor} -- Tensor of shape 2 x SMILES_tokens
 
         Returns:
-            float -- [description]
+            float -- Rewward
         """
 
         # Test the compound

--- a/paccmann_generator/drug_evaluators/tox21.py
+++ b/paccmann_generator/drug_evaluators/tox21.py
@@ -64,7 +64,7 @@ class Tox21(DrugEvaluator):
             smiles_tensor {torch.Tensor} -- Tensor of shape 2 x SMILES_tokens
 
         Returns:
-            float -- Rewward
+            float -- Reward
         """
 
         # Test the compound

--- a/paccmann_generator/drug_evaluators/tox21.py
+++ b/paccmann_generator/drug_evaluators/tox21.py
@@ -1,0 +1,76 @@
+"""Tox21 evaluator."""
+import rdkit
+from rdkit import Chem
+import argparse
+import json
+import logging
+import os
+import torch
+import pickle
+import sys
+import seaborn as sns
+import matplotlib.pyplot as plt
+from torch import nn
+import numpy as np
+from collections import OrderedDict
+from paccmann_predictor.utils.utils import get_device
+import pandas as pd
+from cytotox.models import MODEL_FACTORY
+from pytoda.smiles.smiles_language import SMILESLanguage
+from pytoda.smiles.transforms import SMILESToTokenIndexes
+from cytotox.utils.utils import disable_rdkit_logging
+from .drug_evaluator import DrugEvaluator
+from pytoda.transforms import Transform
+from pytoda.smiles.transforms import LeftPadding
+
+# toxic_model_path = os.path.join(
+#     os.path.expanduser('~'),
+#     'Box/Molecular_SysBio/data/cytotoxicity/models/Tox21/raw_aug_MCA_5'
+# )
+
+# smiles_language_path = os.path.join(
+#     os.path.expanduser('~'),
+#     'Box/Molecular_SysBio/data/cytotoxicity/smiles/smiles_language_chembl_gdsc_ccle_tox21_zinc.pkl'
+# )
+
+
+
+class Tox21(DrugEvaluator):
+    """
+    Tox21 evaluation class.
+    Inherits from DrugEvaluator and evaluates the Tox21 score of a SMILES.
+    """
+
+    def __init__(self):
+
+        super(Tox21, self).__init__()
+
+    def __call__(self, mol):
+        """
+        Returns the Tox21 of a SMILES string or a RdKit molecule.
+        """
+        # Check if molecule is valid
+        # Error handling.
+        if type(mol) == rdkit.Chem.rdchem.Mol:
+            pass
+        elif type(mol) == str:
+            mol = Chem.MolFromSmiles(mol, sanitize=False)
+            if mol is None:
+                raise ValueError("Invalid SMILES string.")
+        else:
+            raise TypeError("Input must be from {str, rdkit.Chem.rdchem.Mol}")
+        
+        return self.tox21_score(mol)
+    
+
+    def tox21_score(self, mol)
+        # model.load(path)
+        with open(os.path.join(tox21_model_path, 'model_params.json')) as f:
+            tox21_params = json.load(f)
+        mol = MODEL_FACTORY['mca'](tox21_params)
+        # Test the compound
+        smiles_t = LeftPadding(Chem.MolFromSmiles(mol),pad_len=300)
+        pred_tox21_per_task, pred_dict = tox21_predictor(smiles_t)
+        pred_tox21_average = sum(pred_tox21_per_task)/12
+
+        return pred_tox21_average

--- a/paccmann_generator/filter_generated_drugs.py
+++ b/paccmann_generator/filter_generated_drugs.py
@@ -8,6 +8,8 @@ from .drug_evaluators.esol import ESOL
 from .drug_evaluators.molecular_weight import MolecularWeight
 from .drug_evaluators.qed import QED
 from .drug_evaluators.sas import SAS
+from .drug_evaluators.tox21 import Tox21
+from .drug_evaluators.organdb import OrganDB
 
 
 def filter_generated_drugs(
@@ -16,7 +18,9 @@ def filter_generated_drugs(
         'SAS': [1, 4],
         'QED': [0.3, 1],
         'ESOL': [-10, -2],
-        'MolecularWeight': [0, 1000]
+        'MolecularWeight': [0, 1000],
+        'Tox21': [0,0.4999],
+        'OrganDB': [0,0.4999]
     },
     overwrite_csv=False,
     csv_save=True,
@@ -69,6 +73,8 @@ def filter_generated_drugs(
     qed = QED()
     molecular_weight = MolecularWeight()
     esol = ESOL()
+    tox21 = Tox21()
+    organdb = OrganDB()
 
     # Compute scores
     molecules = data['SMILES'].apply(Chem.MolFromSmiles)
@@ -76,6 +82,8 @@ def filter_generated_drugs(
     data['SAS'] = molecules.apply(sas)
     data['ESOL'] = molecules.apply(esol)
     data['MolecularWeight'] = molecules.apply(molecular_weight)
+    data['Tox21'] = molecules.apply(tox21)
+    data['OrganDB'] = molecules.apply(organdb)
     data['ID'] = data.apply(
         lambda row: hashlib.
         md5(f'{row["cell_line"]}-{row["SMILES"]}'.encode('utf-8')).hexdigest(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytoda @ git+https://git@github.com/PaccMann/paccmann_datasets@0.0.1
+pytoda @ git+https://git@github.com/PaccMann/paccmann_datasets@latest
 numpy>=1.14.3
 pandas>=0.24.1
 torch>=1.0.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'ali.oskooei@gmail.com, joriscadow@gmail.com'
     ),
     install_requires=[
-        'numpy', 'pandas', 'matplotlib', 'seaborn', 'pytoda>=0.0.1',
+        'numpy', 'pandas', 'matplotlib', 'seaborn', 'pytoda>=0.0.4',
         'torch>=1.0.0', 'six>=1.12.0'
     ],
     packages=find_packages('.'),


### PR DESCRIPTION
 This code does not yet allow to integrate drug evaluators (no code for that in training scripts). Attempting to merge now into `dev` to avoid merge conflicts.

- Added Drug Evaluator classes für models trained on Tox21 (environmental toxicity), OrganDB (organ-specific cytotoxicity), SIDER (physiological side effects of drugs) and ClinTox (Does drug get FDA approval? And will it fail in clinical trials?)
- Added unittest for OrganDB class (since it is most complex and supersedes the others mostly)
- refactor to reflect changes in `paccmann_chemistry` (change `load_model` to `load`).
- bumping pytoda

Attempting to merge despite failing build (cytotox is not yet public)
